### PR TITLE
Fixed broken github cdn url in example

### DIFF
--- a/example.html
+++ b/example.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>jQuery-sutuMask</title>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<script type="text/javascript" src="http://code.jquery.com/jquery-1.8.3.min.js"></script>
+<script type="text/javascript" src="https://rawgit.com/sutunam/jquery-sutuMask/master/jquery.sutumask.js"></script>
+<script type="text/javascript">
+(function ($) {
+	$(function () {
+		$('a').toggle(function() {
+	        $('img').sutuMask();
+	    }, function() {
+	        $('img').sutuUnmask();
+	    });
+	});
+})(jQuery);
+</script>
+</head>
+<body>
+<h1>jQuery-sutuMask</h1>
+<p>A plugin to add mask / overlay to elements</p>
+
+<p><a href="#">Toggle mask on image</a></p>
+
+<img src="http://sutunam.github.io/jquery-sutuMask/sutunam-2years.jpg" />
+</body>
+</html>


### PR DESCRIPTION
Your [example](http://sutunam.github.io/jquery-sutuMask/example.html) is broken because of a bad link.
If you have to execute a script using github as cdn, use [rawgit.com](http://rawgit.com) instead of [raw.github.com](https://raw.github.com).

Usage : `https://rawgit.com/user/repository/branch/pathtofile`
